### PR TITLE
Update language.py

### DIFF
--- a/knowhizService/pipeline/science/prompts/subjects_zeroshot_flashcards_prompts/language.py
+++ b/knowhizService/pipeline/science/prompts/subjects_zeroshot_flashcards_prompts/language.py
@@ -9,24 +9,40 @@ class Language_ZeroshotPrompts(ZeroshotPrompts):
         """
         prompt = \
         """
-        You are a great language instructor,
-        Here is a language learning topic: {extracted_course_name_domain}
-        Generate a list of chapters for learning this topic. Avoid including any methodological chapter topics.
-        Make sure to mention multiple language families such as Indo-European, Sino-Tibetan, Afro-Asiatic.
-        One flashcard must use a non-english, non-european langauge in a sentence and compare it to a english sentence.
-        
+        You are a skilled language instructor.
+        The student wants to learn the following language: {extracted_course_name_domain}
 
-        Note the "Course name" key should exactly match the topic or a suitably rephrased version.
+        Generate a structured course with chapters specifically designed for learning this language. 
+        If the language is French, Japanese, Mandarin, Spanish, or Standard Arabic (Modern Standard Arabic),
+        make the content tailored directly to that language’s script, phonology, grammar, vocabulary, and culture.
+        If it is another language, still generate a language-appropriate course.
 
-        Output your response in **valid JSON format only**, using the structure:
+        Each chapter should represent a major step in language learning (alphabet/characters, basic pronunciation,
+        core grammar, key phrases, conversation skills, listening/reading practice, cultural context, advanced vocabulary, etc.).
 
-        {{
-        "Course name": "Your Course Title Here",
-        "Chapters": [
-            "🗂️ Chapter 1",
-            "🧠 Chapter 2",
-            ...
-        ]
-        }}
+        Ensure at least one flashcard per chapter compares a sentence in the target language with its English equivalent. 
+        Examples: 
+        - French: "Je mange une pomme." ↔ "I am eating an apple."
+        - Japanese: "私はリンゴを食べます。" ↔ "I eat an apple."
+        - Mandarin: "我在吃苹果。" ↔ "I am eating an apple."
+        - Spanish: "Estoy comiendo una manzana." ↔ "I am eating an apple."
+        - Standard Arabic (MSA): "أنا آكل تفاحة." ↔ "I am eating an apple."
+
+        For Japanese and Mandarin, include script-specific guidance (kana/kanji for Japanese; characters, pinyin, and tones for Mandarin).
+        For Standard Arabic, include Arabic script, basic orthography/diacritics, root-and-pattern morphology, and MSA-focused grammar.
+        For Spanish, emphasize verb conjugations (present, preterite, imperfect), gender/number agreement, and common idioms.
+
+        Output your response in **valid JSON format only**, using this structure:
+
+        {
+          "Course name": "Your Course Title Here",
+          "Chapters": [
+            "🗂️ Chapter 1: ...",
+            "🧠 Chapter 2: ...",
+            "🗣️ Chapter 3: ...",
+            "📚 Chapter 4: ...",
+            "🛫 Chapter 5: ..."
+          ]
+        }
         """
         return prompt


### PR DESCRIPTION
removed the original requirement to list language families and to avoid “methodological” chapters, and made the chapter examples more language-learning specific.